### PR TITLE
fix class DataBuilder

### DIFF
--- a/DPSMate_DataBuilder.lua
+++ b/DPSMate_DataBuilder.lua
@@ -803,7 +803,6 @@ DPSMate.DB.PLAYER_TARGET_CHANGED = function()
 		if not name then return end
 		local pet = UnitName("targetpet")
 		local classLoc, class = UnitClass("target")
-		class = class or classLoc
 		if not class then return end
 		local fac = UnitFactionGroup("target") or ""
 		local level = UL("target")
@@ -912,9 +911,9 @@ function DPSMate.DB:OnGroupUpdate()
 				DPSMateUser[name] = {[1] = self.userlen}
 				DPSMate.UserId = nil
 			end
-			local resolvedClass = classEng or classLoc
-			if resolvedClass then
-				DPSMateUser[name][2] = strlower(resolvedClass)
+
+			if classEng then
+				DPSMateUser[name][2] = strlower(classEng)
 			elseif not DPSMateUser[name][2] then
 				allNamesResolved = false
 			end


### PR DESCRIPTION
https://github.com/jrc13245/DPSMate/issues/12

 Loc_class and EN_class cannot be combined in a variable.
I'm not sure why, but I made this mistake too.

You also use the “or” operator in the variable, although it would be more logical to use “and” if you need both types of values, but this also doesn't work for the reason above.